### PR TITLE
Add support for Code::Stats

### DIFF
--- a/src/accounts/codestats.ts
+++ b/src/accounts/codestats.ts
@@ -28,22 +28,20 @@ export class CodeStatsAccount implements Account {
 
   async getReport(day: number) {
     if (!this.dates.size) {
-        await this.fetchDates();
+      await this.fetchDates();
     }
 
     return this.dates.has(day) ? this.dates.get(day) as number : 0;
   }
 
   async fetchDates() {
-      console.log('Fetching dates');
-      try {
-        const userData = await (await fetch(`${BASE_URL}${this.username}`)).text();
-        const userDates = JSON.parse(userData).dates;
-        for (const date in userDates) {
-            this.dates.set(getDayIndex(M(date)), userDates[date]);
-        }
-      } catch {
-        return null;
+    try {
+      const userDates = (await (await fetch(`${BASE_URL}${this.username}`)).json()).dates;
+      for (const date in userDates) {
+        this.dates.set(getDayIndex(M(date)), userDates[date]);
       }
+    } catch {
+      return null;
+    }
   }
 }

--- a/src/accounts/codestats.ts
+++ b/src/accounts/codestats.ts
@@ -1,0 +1,49 @@
+import fetch from 'node-fetch';
+import chalk from 'chalk';
+import * as M from 'moment';
+
+import {Account} from './account';
+import {getDayIndex} from '../time';
+import {parseAccountUrl} from '../libs/urls';
+
+const BASE_URL = 'https://codestats.net/api/users/';
+
+export class CodeStatsAccount implements Account {
+  static title = 'Code::Stats';
+  static aliases = ['codestats', 'cs'];
+  static statistic = 'XP gained';
+  static theme = chalk.hex('#3e4053');
+
+  constructor(private username: string) {}
+
+  get canonicalUrl() {
+    return `https://codestats.net/users/${this.username}`;
+  }
+
+  static resolveUrlToId(url: string) {
+    return parseAccountUrl(url, /\/\/codestats.net\/users\/([^/\s]+)/i);
+  }
+
+  dates: Map<number, number> = new Map();
+
+  async getReport(day: number) {
+    if (!this.dates.size) {
+        await this.fetchDates();
+    }
+
+    return this.dates.has(day) ? this.dates.get(day) as number : 0;
+  }
+
+  async fetchDates() {
+      console.log('Fetching dates');
+      try {
+        const userData = await (await fetch(`${BASE_URL}${this.username}`)).text();
+        const userDates = JSON.parse(userData).dates;
+        for (const date in userDates) {
+            this.dates.set(getDayIndex(M(date)), userDates[date]);
+        }
+      } catch {
+        return null;
+      }
+  }
+}

--- a/src/libs/accounts.ts
+++ b/src/libs/accounts.ts
@@ -8,6 +8,7 @@ import {WakaTimeAccount} from '../accounts/wakatime';
 import {GitLabAccount} from '../accounts/gitlab';
 import {ReverseEngineeringAccount} from '../accounts/stackexchange/reverseengineering';
 import {HackerRankAccount} from '../accounts/hackerrank';
+import {CodeStatsAccount} from '../accounts/codestats';
 
 export interface AccountType {
   new(url: string): Account;
@@ -25,6 +26,7 @@ const accountTypes = [
   GitLabAccount,
   ReverseEngineeringAccount,
   HackerRankAccount,
+  CodeStatsAccount
 ] as any as AccountType[];
 
 export function getAccountType(account: Account): AccountType {


### PR DESCRIPTION
I've found about this project on asciicinema and I loved it!

Here's a little contribution that adds support to [Code::Stats](https://codestats.net). This is how the stats look like with it:

![2018-11-07-195032_429x147_scrot](https://user-images.githubusercontent.com/388373/48163434-cfa68980-e2c6-11e8-8156-9fb2d560f06e.png)

The code is heavily based on the github one, but I decided to use their API instead of parsing the HTML output. This is my very first time coding in Typescript, so I hope I didn't do any mistake :crossed_fingers: 

I'm not sure if there's any rule to decide which color to use for each account, so I simply picked the most dominant color from the Code::Stats site. Please let me know if you would prefer some other choice.
